### PR TITLE
CAP_PROP_FRAME_HEIGHT issue

### DIFF
--- a/chapter1/chapter1.py
+++ b/chapter1/chapter1.py
@@ -93,7 +93,7 @@ def main():
         capture.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 480)
     else:
         capture.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
-        capture.set(cv2.CV_CAP_PROP_FRAME_HEIGHT, 480)
+        capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
 
     # start graphical user interface
     app = wx.App()

--- a/chapter2/chapter2.py
+++ b/chapter2/chapter2.py
@@ -80,7 +80,7 @@ def main():
         capture.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 480)
     else:
         capture.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
-        capture.set(cv2.CV_CAP_PROP_FRAME_HEIGHT, 480)
+        capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
 
     # start graphical user interface
     app = wx.App()

--- a/chapter3/chapter3.py
+++ b/chapter3/chapter3.py
@@ -52,7 +52,7 @@ def main():
         capture.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 480)
     else:
         capture.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
-        capture.set(cv2.CV_CAP_PROP_FRAME_HEIGHT, 480)
+        capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
 
     # start graphical user interface
     app = wx.App()

--- a/chapter4/calibrate.py
+++ b/chapter4/calibrate.py
@@ -17,6 +17,7 @@ class CameraCalibration(BaseLayout):
         the chessboard approach described here:
         http://docs.opencv.org/doc/tutorials/calib3d/camera_calibration/camera_calibration.html
     """
+
     def _init_custom_layout(self):
         """Initializes camera calibration"""
         # setting chessboard size
@@ -107,7 +108,7 @@ class CameraCalibration(BaseLayout):
                 img_points2, _ = cv2.projectPoints(self.obj_points[i],
                                                    rvecs[i], tvecs[i], K, dist)
                 error = cv2.norm(self.img_points[i], img_points2,
-                                 cv2.NORM_L2)/len(img_points2)
+                                 cv2.NORM_L2) / len(img_points2)
                 mean_error += error
 
             print "mean error=", mean_error
@@ -136,8 +137,12 @@ def main():
     if not(capture.isOpened()):
         capture.open()
 
-    capture.set(cv2.cv.CV_CAP_PROP_FRAME_WIDTH, 640)
-    capture.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 480)
+    if hasattr(cv2, 'cv'):
+        capture.set(cv2.cv.CV_CAP_PROP_FRAME_WIDTH, 640)
+        capture.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 480)
+    else:
+        capture.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
+        capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
 
     # start graphical user interface
     app = wx.App()

--- a/chapter7/chapter7.py
+++ b/chapter7/chapter7.py
@@ -279,7 +279,7 @@ def main():
         capture.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 480)
     else:
         capture.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
-        capture.set(cv2.CV_CAP_PROP_FRAME_HEIGHT, 480)
+        capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
 
     # start graphical user interface
     app = wx.App()


### PR DESCRIPTION
This PR fixes #14: typos for `CAP_PROP_FRAME_HEIGHT` in OpenCV3.